### PR TITLE
Adding defaults to test instances to avoid warnings during tests

### DIFF
--- a/app/mixins/ss-transition.js
+++ b/app/mixins/ss-transition.js
@@ -12,13 +12,13 @@ export default Mixin.create({
     let transitionMode = this.get('transitionMode');
     if (isBlank(transitionMode)) {
       if (window.console != null && window.console.warn != null) {
-        window.console.warn("transitionMode isn't specificed. It should be a string (i.e. fade). Using default");
+        window.console.warn("transitionMode isn't specified. It should be a string (i.e. fade). Using default");
       }
     }
     let transitionDuration = this.get('transitionDuration');
     if (isBlank(transitionDuration)) {
       if (window.console != null && window.console.warn != null) {
-        window.console.warn("transitionDuration isn't specificed. It should be an integer for milliseconds (i.e. 500).Using default");
+        window.console.warn("transitionDuration isn't specified. It should be an integer for milliseconds (i.e. 500).Using default");
       }
     }
   },

--- a/test-support/integration/mixins/ss-transition-test.js
+++ b/test-support/integration/mixins/ss-transition-test.js
@@ -33,13 +33,13 @@ let buildCSS = function(style) {
 
 test('can render with mixin', function(assert) {
   assert.expect(1);
-  this.render(hbs`{{ss-test}}`);
+  this.render(hbs`{{ss-test transitionMode="fade" transitionDuration=500}}`);
   assert.ok(this.$('.ss.test').length, 1);
 });
 
 test('detects active', function(assert) {
   assert.expect(4);
-  this.render(hbs`{{ss-test class="visible active"}}`);
+  this.render(hbs`{{ss-test class="visible active" transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
   // Everything should start false
@@ -51,7 +51,7 @@ test('detects active', function(assert) {
 
 test('detects hidden', function(assert) {
   assert.expect(4);
-  this.render(hbs`{{ss-test class="hidden"}}`);
+  this.render(hbs`{{ss-test class="hidden" transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
   // Everything should start false
@@ -63,7 +63,7 @@ test('detects hidden', function(assert) {
 
 test('detects animating in', function(assert) {
   assert.expect(4);
-  this.render(hbs`{{ss-test class="visible animating in"}}`);
+  this.render(hbs`{{ss-test class="visible animating in" transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
   // Everything should start false
@@ -75,7 +75,7 @@ test('detects animating in', function(assert) {
 
 test('detects animating out', function(assert) {
   assert.expect(4);
-  this.render(hbs`{{ss-test class="visible animating out"}}`);
+  this.render(hbs`{{ss-test class="visible animating out" transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
   // Everything should start false
@@ -87,7 +87,7 @@ test('detects animating out', function(assert) {
 
 test('check properties', function(assert) {
   assert.expect(18);
-  this.render(hbs`{{ss-test}}`);
+  this.render(hbs`{{ss-test transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
   // Everything should start false
@@ -126,7 +126,7 @@ test('check properties', function(assert) {
 
 test('transitions in', function(assert) {
   assert.expect(12);
-  this.render(hbs`{{ss-test}}`);
+  this.render(hbs`{{ss-test transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
 
@@ -153,7 +153,7 @@ test('transitions in', function(assert) {
 
 test('transitions out', function(assert) {
   assert.expect(16);
-  this.render(hbs`{{ss-test}}`);
+  this.render(hbs`{{ss-test transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
 
@@ -186,7 +186,7 @@ test('transitions out', function(assert) {
 
 test('transitions in then out cancels in', function(assert) {
   assert.expect(16);
-  this.render(hbs`{{ss-test}}`);
+  this.render(hbs`{{ss-test transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
 
@@ -223,7 +223,7 @@ test('transitions in then out cancels in', function(assert) {
 
 test('transitions out then in cancels out', function(assert) {
   assert.expect(20);
-  this.render(hbs`{{ss-test}}`);
+  this.render(hbs`{{ss-test transitionMode="fade" transitionDuration=500}}`);
   let ssTestElement = this.$('.ss.test');
   let ssTest = this.container.cache['-view-registry:main'][ssTestElement.attr('id')];
 


### PR DESCRIPTION
Getting rid of warnings like these during tests:
```
ok 473 Chrome 78.0 - [627 ms] - Integration | Mixin | ss transition: transitions in               
    ---                                                                                                                                  
        browser log: |                                                                                                                   
            WARN: transitionMode isn't specificed. It should be a string (i.e. fade). Using default                                      
            WARN: transitionDuration isn't specificed. It should be an integer for milliseconds (i.e. 500).Using default                 
```